### PR TITLE
Feature/user api

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,0 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
-
-DATABASE_URL="postgresql://postgres:1234@localhost:5432/carmate?schema=public"

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,8 @@
   "semi": true,
   "tabWidth": 2,
   "useTabs": false,
-  "printWidth": 80,
-  "trailingComma": "all"
+  "printWidth": 100,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "endOfLine": "auto"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.16.2",
+        "bcrypt": "^6.0.0",
+        "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "prisma": "^6.16.2",
         "zod": "^4.1.11"
       },
       "devDependencies": {
+        "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.6.1",
@@ -302,6 +305,16 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "license": "MIT"
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -460,6 +473,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -542,6 +556,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -614,6 +642,18 @@
         "magicast": {
           "optional": true
         }
+      }
+    },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -847,9 +887,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -970,6 +1010,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1838,11 +1879,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/nypm": {
       "version": "0.6.2",
@@ -2059,6 +2120,7 @@
       "integrity": "sha512-aRvldGE5UUJTtVmFiH3WfNFNiqFlAtePUxcI0UEGlnXCX7DqhiMT5TRYwncHFeA/Reca5W6ToXXyCMTeFPdSXA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.16.2",
         "@prisma/engines": "6.16.2"
@@ -2480,6 +2542,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,14 @@
       "dependencies": {
         "@prisma/client": "^6.16.2",
         "express": "^5.1.0",
-        "prisma": "^6.16.2"
+        "jsonwebtoken": "^9.0.2",
+        "prisma": "^6.16.2",
+        "zod": "^4.1.11"
       },
       "devDependencies": {
+        "@types/express": "^5.0.3",
+        "@types/jsonwebtoken": "^9.0.10",
+        "@types/node": "^24.6.1",
         "eslint": "^9.36.0",
         "prettier": "^3.6.2",
         "typescript": "^5.9.2"
@@ -297,10 +302,63 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
+      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
+      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -310,6 +368,78 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.1.tgz",
+      "integrity": "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -442,6 +572,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -734,6 +870,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1475,6 +1620,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -1515,11 +1703,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -2017,6 +2247,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
@@ -2246,6 +2488,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2317,6 +2566,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@types/express": "^5.0.3",
+    "@types/jsonwebtoken": "^9.0.10",
+    "@types/node": "^24.6.1",
     "eslint": "^9.36.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2"
@@ -20,6 +23,8 @@
   "dependencies": {
     "@prisma/client": "^6.16.2",
     "express": "^5.1.0",
-    "prisma": "^6.16.2"
+    "jsonwebtoken": "^9.0.2",
+    "prisma": "^6.16.2",
+    "zod": "^4.1.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.6.1",
@@ -22,6 +23,8 @@
   },
   "dependencies": {
     "@prisma/client": "^6.16.2",
+    "bcrypt": "^6.0.0",
+    "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "prisma": "^6.16.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,16 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model Company {
+  id        Int      @id @default(autoincrement())
+  name      String   @db.VarChar(100)
+  authCode  String   @unique @map("auth_code") @db.VarChar(100)
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // users User[]
+  // cars  Car[]
+
+  @@map("companies")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../src/generated/prisma"
 }
 
 datasource db {
@@ -21,8 +20,26 @@ model Company {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  // users User[]
   // cars  Car[]
+  User User[]
 
   @@map("companies")
+}
+
+model User {
+  id             Int      @id @default(autoincrement())
+  name           String   @db.VarChar(20)
+  email          String   @unique @db.VarChar(100)
+  password       String   @db.VarChar(255)
+  employeeNumber String   @unique @map("employee_number") @db.VarChar(20)
+  phoneNumber    String   @map("phone_number") @db.VarChar(20)
+  imageUrl       String?  @map("image_url") @db.VarChar(255)
+  isAdmin        Boolean  @default(false) @map("is_admin")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
+
+  company   Company @relation(fields: [companyId], references: [id])
+  companyId Int     @map("company_id")
+
+  @@map("users")
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import companyRoute from './routes/company-route.js';
+
+const app = express();
+const port = 3001;
+
+app.use('/companies', companyRoute);
+
+app.listen(port, () => {
+  console.log(`Server is running at http://localhost:${port}`);
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,17 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
 import express from 'express';
 import companyRoute from './routes/company-route.js';
+import userRoute from './routes/user-route.js';
 
 const app = express();
 const port = 3001;
 
+app.use(express.json());
+
 app.use('/companies', companyRoute);
+app.use('/users', userRoute);
 
 app.listen(port, () => {
   console.log(`Server is running at http://localhost:${port}`);

--- a/src/configs/async-handler.ts
+++ b/src/configs/async-handler.ts
@@ -1,0 +1,9 @@
+export default function asyncHandler(handler) {
+  return async function (req, res, next) {
+    try {
+      await handler(req, res);
+    } catch (e) {
+      next(e);
+    }
+  };
+}

--- a/src/configs/async-handler.ts
+++ b/src/configs/async-handler.ts
@@ -1,5 +1,8 @@
-export default function asyncHandler(handler) {
-  return async function (req, res, next) {
+import { Request, Response, NextFunction } from 'express';
+import { AsyncRequestHandler } from '../types/express.js';
+
+export default function asyncHandler(handler: AsyncRequestHandler) {
+  return async function (req: Request, res: Response, next: NextFunction) {
     try {
       await handler(req, res);
     } catch (e) {

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -1,0 +1,14 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+function getEnvVar(name: string): string {
+  const value = process.env[name];
+  if (value === undefined) {
+    throw new Error(`환경 변수 ${name}이(가) 설정되지 않았습니다.`);
+  }
+  return value;
+}
+
+export const ACCESS_TOKEN_SECRET = getEnvVar('ACCESS_TOKEN_SECRET');
+export const REFRESH_TOKEN_SECRET = getEnvVar('REFRESH_TOKEN_SECRET');

--- a/src/configs/custom-error.ts
+++ b/src/configs/custom-error.ts
@@ -1,0 +1,56 @@
+export interface ErrorDetail {
+  field: string;
+  message: string;
+}
+
+// 추상 클래스: 모든 커스텀 에러의 부모
+export abstract class AppError extends Error {
+  public statusCode: number;
+  public details?: ErrorDetail[];
+
+  constructor(message: string, statusCode: number, details?: ErrorDetail[]) {
+    super(message);
+    this.statusCode = statusCode;
+    this.details = details ?? [];
+
+    // TS에서 상속 오류 방지
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// 개별 에러 클래스들
+export class UnauthorizedError extends AppError {
+  constructor(message = '인증이 필요합니다.') {
+    super(message, 401);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = '접근 권한이 없습니다.') {
+    super(message, 403);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = '리소스를 찾을 수 없습니다.') {
+    super(message, 404);
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message = '데이터가 이미 존재합니다.') {
+    super(message, 409);
+  }
+}
+
+export class BadRequestError extends AppError {
+  constructor(message = '잘못된 요청입니다.', details?: ErrorDetail[]) {
+    super(message, 400, details);
+  }
+}
+
+export class InternalServerError extends AppError {
+  constructor(message = '서버 내부 오류가 발생했습니다.') {
+    super(message, 500);
+  }
+}

--- a/src/configs/prisma-client.ts
+++ b/src/configs/prisma-client.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/src/configs/token.ts
+++ b/src/configs/token.ts
@@ -1,0 +1,18 @@
+import jwt from 'jsonwebtoken';
+import { ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET } from './constants.js';
+
+function generateTokens(userId: number) {
+  if (!ACCESS_TOKEN_SECRET || !REFRESH_TOKEN_SECRET) {
+    throw new Error('토큰 시크릿이 설정되지 않았습니다.');
+  }
+  const accessToken = jwt.sign({ id: userId }, ACCESS_TOKEN_SECRET, {
+    expiresIn: '1h',
+  });
+  const refreshToken = jwt.sign({ id: userId }, REFRESH_TOKEN_SECRET, {
+    expiresIn: '7d',
+  });
+
+  return { accessToken, refreshToken };
+}
+
+export { generateTokens };

--- a/src/controllers/company-controller.ts
+++ b/src/controllers/company-controller.ts
@@ -1,0 +1,18 @@
+import type { Request, Response } from 'express';
+import companyServie from '../services/company-service.js';
+
+const companyController = {
+  async create(req: Request, res: Response) {
+    // req.user 없는 경우 에러 처리
+    const companyData = req.body;
+    const newCompany = await companyServie.create(companyData);
+    res.status(201).json(newCompany);
+  },
+
+  async update() {},
+  async delete() {},
+  async getAll() {},
+  async getById() {}, // 참조하는 변수에 따라
+};
+
+export default companyController;

--- a/src/controllers/user-controller.ts
+++ b/src/controllers/user-controller.ts
@@ -1,0 +1,53 @@
+import type { Request, Response } from 'express';
+import userService from '../services/user-service.js';
+
+const userController = {
+  async createUser(req: Request, res: Response) {
+    const userData = req.body;
+    const newUser = await userService.createUser(userData);
+    res.status(201).json(newUser);
+  },
+
+  async getMe(req: Request, res: Response) {
+    // 인증 미들웨어에서 추가해준 user.id를 사용
+    const userId = req.user.id;
+    const user = await userService.getUserById(userId);
+    res.status(200).json(user);
+  },
+
+  async updateMe(req: Request, res: Response) {
+    // 인증 미들웨어에서 추가해준 user.id를 사용
+    const userId = req.user.id;
+    const userData = req.body;
+    const updatedUser = await userService.updateUser(userId, userData);
+    res.status(200).json(updatedUser);
+  },
+
+  async deleteMe(req: Request, res: Response) {
+    // 인증 미들웨어에서 추가해준 user.id를 사용
+    const userId = req.user.id;
+    await userService.deleteUser(userId);
+    res.status(200).json({ message: '유저 삭제 성공' });
+  },
+
+  async getUserById(req: Request, res: Response) {
+    const userId = Number(req.params.id);
+    const user = await userService.getUserById(userId);
+    res.status(200).json(user);
+  },
+
+  async updateUser(req: Request, res: Response) {
+    const userId = Number(req.params.id);
+    const userData = req.body;
+    const updatedUser = await userService.updateUser(userId, userData);
+    res.status(200).json(updatedUser);
+  },
+
+  async deleteUser(req: Request, res: Response) {
+    const userId = Number(req.params.id);
+    await userService.deleteUser(userId);
+    res.status(204).send();
+  },
+};
+
+export default userController;

--- a/src/dtos/company-dto.ts
+++ b/src/dtos/company-dto.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+// Zod 스키마 정의 (Validator 역할)
+export const createCompanySchema = z.object({
+  name: z.string().min(1, { message: '회사 이름은 필수입니다.' }),
+  authCode: z.string().length(6, { message: '인증 코드는 6자리여야 합니다.' }),
+});
+
+export const updateCompanySchema = z.object({
+  name: z.string().min(1, { message: '회사 이름은 필수입니다.' }),
+  authCode: z.string().length(6, { message: '인증 코드는 6자리여야 합니다.' }),
+});
+
+// 스키마에서 타입 추론 (DTO 역할)
+export type CreateCompanyDto = z.infer<typeof createCompanySchema>;

--- a/src/dtos/user-dto.ts
+++ b/src/dtos/user-dto.ts
@@ -1,0 +1,19 @@
+export interface CreateUserDto {
+  name: string;
+  email: string;
+  employeeNumber: string;
+  phoneNumber: string;
+  password: string;
+  passwordConfirmation: string;
+  company: string;
+  companyCode: string;
+}
+
+export interface UpdateUserDto {
+  currentPassword?: string;
+  employeeNumber?: string;
+  phoneNumber?: string;
+  password?: string;
+  passwordConfirmation?: string;
+  imageUrl?: string;
+}

--- a/src/dtos/user-dto.ts
+++ b/src/dtos/user-dto.ts
@@ -1,13 +1,37 @@
-export interface CreateUserDto {
-  name: string;
-  email: string;
-  employeeNumber: string;
-  phoneNumber: string;
-  password: string;
-  passwordConfirmation: string;
-  company: string;
-  companyCode: string;
-}
+import { z } from 'zod';
+
+export const createUserSchema = z
+  .object({
+    name: z.string().min(1, '이름은 필수입니다.'),
+    email: z.string().email('올바른 이메일 형식이 아닙니다.'),
+    employeeNumber: z.string().min(1, '사원번호는 필수입니다.'),
+    phoneNumber: z.string().min(1, '전화번호는 필수입니다.'),
+    password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
+    passwordConfirmation: z.string(),
+    company: z.string().min(1, '회사 이름은 필수입니다.'),
+    companyCode: z.string().length(6, '회사 코드는 6자리여야 합니다.'),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: '비밀번호와 비밀번호 확인이 일치하지 않습니다.',
+    path: ['passwordConfirmation'], // 오류가 발생할 필드 지정
+  });
+
+export const updateUserSchema = z
+  .object({
+    currentPassword: z.string().min(1, '현재 비밀번호는 필수입니다.'),
+    employeeNumber: z.string().optional(),
+    phoneNumber: z.string().optional(),
+    password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.').optional(),
+    passwordConfirmation: z.string().optional(),
+    imageUrl: z.string().optional(),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: '비밀번호와 비밀번호 확인이 일치하지 않습니다.',
+    path: ['passwordConfirmation'],
+  });
+
+// 스키마에서 타입 추론 (DTO 역할)
+export type CreateUserDto = z.infer<typeof createUserSchema>;
 
 export interface UpdateUserDto {
   currentPassword?: string;

--- a/src/middlewares/authenticate.ts
+++ b/src/middlewares/authenticate.ts
@@ -39,7 +39,7 @@ export async function authenticate(req: Request, _res: Response, next: NextFunct
       where: { id: decoded.id },
     });
 
-    req.user = us6er;
+    req.user = user;
 
     next();
   } catch (err) {

--- a/src/middlewares/authenticate.ts
+++ b/src/middlewares/authenticate.ts
@@ -1,0 +1,48 @@
+import type { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import prisma from '../configs/prisma-client.js';
+import { ACCESS_TOKEN_SECRET } from '../configs/constants.js';
+import {
+  UnauthorizedError,
+  ForbiddenError,
+  BadRequestError,
+  NotFoundError,
+} from '../configs/custom-error.js';
+
+export async function authenticate(req: Request, _res: Response, next: NextFunction) {
+  const authHeader = req.headers['authorization'];
+
+  if (!authHeader) {
+    return next(new UnauthorizedError('Access Token이 필요합니다.'));
+  }
+
+  // "Bearer ..." 형식인지 확인
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return next(new BadRequestError('잘못된 Authorization 헤더 형식입니다.'));
+  }
+
+  const token = parts[1];
+
+  try {
+    if (!token) {
+      return next(new NotFoundError('토큰이 존재하지 않습니다.'));
+    }
+    const decoded = jwt.verify(token, ACCESS_TOKEN_SECRET);
+
+    // verify 결과 타입이 string | JwtPayload 임
+    if (typeof decoded === 'string' || !('id' in decoded)) {
+      throw new ForbiddenError('유효하지 않은 Access Token입니다.');
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: decoded.id },
+    });
+
+    req.user = us6er;
+
+    next();
+  } catch (err) {
+    return next(new ForbiddenError('Access Token 검증 실패'));
+  }
+}

--- a/src/middlewares/authenticate.ts
+++ b/src/middlewares/authenticate.ts
@@ -39,6 +39,10 @@ export async function authenticate(req: Request, _res: Response, next: NextFunct
       where: { id: decoded.id },
     });
 
+    if (!user) {
+      return next(new NotFoundError('사용자를 찾을 수 없습니다.'));
+    }
+
     req.user = user;
 
     next();

--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -1,0 +1,79 @@
+import type { Request, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
+import { ZodError } from 'zod';
+import {
+  AppError,
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+  UnauthorizedError,
+} from '../configs/custom-error.js'; // 앞서 정의하신 AppError 추상 클래스 + 상속 에러들
+
+export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction) {
+  console.error('===== Global Error Handler =====');
+
+  // ✅ Zod 에러
+  if (err instanceof ZodError) {
+    console.error('Zod validation error:', err.issues);
+    const errorDetails = err.issues.map((issue) => ({
+      field: issue.path.join('.'),
+      message: issue.message,
+    }));
+    const badRequestError = new BadRequestError('유효성 검증에 실패했습니다.', errorDetails);
+    return res.status(badRequestError.statusCode).json({
+      message: badRequestError.message,
+      details: badRequestError.details,
+    });
+  }
+
+  // ✅ Prisma 에러
+  if (err instanceof Prisma.PrismaClientValidationError) {
+    console.error('Prisma Validation Error:', err.message);
+    return res.status(400).json({ message: 'Prisma 쿼리 데이터가 유효하지 않습니다.' });
+  }
+
+  if (err instanceof Prisma.PrismaClientKnownRequestError) {
+    console.error('Prisma KnownRequestError:', err.code, err.meta);
+
+    switch (err.code) {
+      case 'P2025':
+        return res.status(404).json({ message: '요청한 데이터를 찾을 수 없습니다.' });
+      case 'P2002': {
+        const field = (err.meta?.['target'] as string[])?.[0];
+        const modelName = err.meta?.['modelName'] as string;
+        const msg = modelName.endsWith('Like')
+          ? '이미 좋아요를 눌렀습니다.'
+          : `${field} 필드의 값이 이미 존재합니다.`;
+        return res.status(409).json({ message: msg });
+      }
+      case 'P2003':
+        return res.status(400).json({ message: '연결된 데이터를 찾을 수 없습니다.' });
+    }
+  }
+
+  // ✅ 비즈니스 로직 에러 (AppError)
+  if (err instanceof AppError) {
+    console.error('Business Error:', {
+      name: err.name,
+      code: err.statusCode,
+      message: err.message,
+      url: req.originalUrl,
+      method: req.method,
+      headers: req.headers.authorization,
+      query: req.query,
+    });
+
+    return res.status(err.statusCode).json({
+      message: err.message,
+      details: err.details ?? [],
+    });
+  }
+
+  // ✅ 잡히지 않은 에러 (Catch-all)
+  console.error('Unhandled Error:', err.stack || err);
+  return res.status(500).json({
+    message: '서버 내부에서 에러가 발생했습니다.',
+  });
+}

--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -1,6 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import { Prisma } from '@prisma/client';
-import { PrismaClientValidationError } from '@prisma/client/runtime/library.js';
+import {
+  PrismaClientValidationError,
+  PrismaClientKnownRequestError,
+} from '@prisma/client/runtime/library.js';
 import { ZodError } from 'zod';
 import {
   AppError,
@@ -33,9 +36,7 @@ export function errorHandler(err: Error, req: Request, res: Response, _next: Nex
   if (err instanceof PrismaClientValidationError) {
     console.error('Prisma Validation Error:', err.message);
     return res.status(400).json({ message: 'Prisma 쿼리 데이터가 유효하지 않습니다.' });
-  }
-
-  if (err instanceof PrismaClientValidationError) {
+  } else if (err instanceof PrismaClientKnownRequestError) {
     console.error('Prisma KnownRequestError:', err.code, err.meta);
 
     switch (err.code) {

--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { Prisma } from '@prisma/client';
+import { PrismaClientValidationError } from '@prisma/client/runtime/library.js';
 import { ZodError } from 'zod';
 import {
   AppError,
@@ -29,12 +30,12 @@ export function errorHandler(err: Error, req: Request, res: Response, _next: Nex
   }
 
   // ✅ Prisma 에러
-  if (err instanceof Prisma.PrismaClientValidationError) {
+  if (err instanceof PrismaClientValidationError) {
     console.error('Prisma Validation Error:', err.message);
     return res.status(400).json({ message: 'Prisma 쿼리 데이터가 유효하지 않습니다.' });
   }
 
-  if (err instanceof Prisma.PrismaClientKnownRequestError) {
+  if (err instanceof PrismaClientValidationError) {
     console.error('Prisma KnownRequestError:', err.code, err.meta);
 
     switch (err.code) {

--- a/src/middlewares/validate.ts
+++ b/src/middlewares/validate.ts
@@ -1,0 +1,19 @@
+import { ZodObject } from 'zod';
+import type { Request, Response, NextFunction } from 'express';
+
+export const validate =
+  (schema: ZodObject) => (req: Request, res: Response, next: NextFunction) => {
+    try {
+      schema.parse({
+        body: req.body,
+        query: req.query,
+        params: req.params,
+      });
+      next();
+    } catch (e: any) {
+      return res.status(400).json({
+        message: 'Validation Error',
+        errors: e.errors,
+      });
+    }
+  };

--- a/src/middlewares/validate.ts
+++ b/src/middlewares/validate.ts
@@ -4,11 +4,9 @@ import type { Request, Response, NextFunction } from 'express';
 export const validate =
   (schema: ZodObject) => (req: Request, res: Response, next: NextFunction) => {
     try {
-      schema.parse({
-        body: req.body,
-        query: req.query,
-        params: req.params,
-      });
+      // 이전 코드: schema.parse({ body: req.body, ... }) -> req.body를 객체로 감싸서 검증했기 때문에 오류 발생
+      // 수정 후: req.body를 직접 검증하도록 변경
+      schema.parse(req.body);
       next();
     } catch (e: any) {
       return res.status(400).json({

--- a/src/repositories/company-repository.ts
+++ b/src/repositories/company-repository.ts
@@ -1,0 +1,17 @@
+import prisma from '../configs/prisma-client.js';
+
+const companyRepository = {
+  async create(companyData) {
+    return prisma.companie.create({
+      data: {
+        companyData,
+      },
+    });
+  },
+  async update() {},
+  async delete() {},
+  async getAll() {},
+  async getById() {},
+};
+
+export default companyRepository;

--- a/src/repositories/company-repository.ts
+++ b/src/repositories/company-repository.ts
@@ -3,10 +3,8 @@ import type { CreateCompanyDto } from '../dtos/company-dto.js';
 
 const companyRepository = {
   async create(companyData: CreateCompanyDto) {
-    return prisma.companie.create({
-      data: {
-        companyData,
-      },
+    return prisma.company.create({
+      data: companyData,
     });
   },
   async update() {},

--- a/src/repositories/company-repository.ts
+++ b/src/repositories/company-repository.ts
@@ -7,6 +7,16 @@ const companyRepository = {
       data: companyData,
     });
   },
+
+  // 유저 회원가입 시, 회사명과 인증코드를 검증하기 위해 추가
+  async findByNameAndAuthCode(name: string, authCode: string) {
+    return prisma.company.findFirst({
+      where: {
+        AND: [{ name }, { authCode }],
+      },
+    });
+  },
+
   async update() {},
   async delete() {},
   async getAll() {},

--- a/src/repositories/company-repository.ts
+++ b/src/repositories/company-repository.ts
@@ -1,7 +1,8 @@
 import prisma from '../configs/prisma-client.js';
+import type { CreateCompanyDto } from '../dtos/company-dto.js';
 
 const companyRepository = {
-  async create(companyData) {
+  async create(companyData: CreateCompanyDto) {
     return prisma.companie.create({
       data: {
         companyData,

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -1,0 +1,46 @@
+import prisma from '../configs/prisma-client.js';
+import type { CreateUserDto, UpdateUserDto } from '../dtos/user-dto.js';
+
+const userRepository = {
+  async create(data: any) { // 서비스에서 가공된 데이터를 받도록 수정
+    return prisma.user.create({
+      data,
+      include: {
+        company: true, // 생성된 유저 정보에 회사 정보를 포함
+      },
+    });
+  },
+
+  async findByEmail(email: string) {
+    return prisma.user.findUnique({
+      where: { email },
+    });
+  },
+
+  async findById(id: number) {
+    return prisma.user.findUnique({
+      where: { id },
+      include: {
+        company: true,
+      },
+    });
+  },
+
+  async update(id: number, userData: UpdateUserDto) {
+    return prisma.user.update({
+      where: { id },
+      data: userData,
+      include: {
+        company: true,
+      },
+    });
+  },
+
+  async delete(id: number) {
+    return prisma.user.delete({
+      where: { id },
+    });
+  },
+};
+
+export default userRepository;

--- a/src/routes/company-route.ts
+++ b/src/routes/company-route.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import asyncHandler from 'src/configs/async-handler';
+import companyController from 'src/controllers/company-controller';
+import { createCompanySchema } from 'src/dtos/company-dto';
+import { validate } from 'src/middlewares/validate';
+
+const router = Router();
+
+router.post('/', validate(createCompanySchema), asyncHandler(companyController.create));
+
+export default router;

--- a/src/routes/company-route.ts
+++ b/src/routes/company-route.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express';
-import asyncHandler from 'src/configs/async-handler';
-import companyController from 'src/controllers/company-controller';
-import { createCompanySchema } from 'src/dtos/company-dto';
-import { validate } from 'src/middlewares/validate';
+import asyncHandler from '../configs/async-handler';
+import companyController from '../controllers/company-controller';
+import { createCompanySchema } from '../dtos/company-dto';
+import { validate } from '../middlewares/validate';
 
 const router = Router();
 

--- a/src/routes/user-route.ts
+++ b/src/routes/user-route.ts
@@ -1,22 +1,21 @@
 import { Router } from 'express';
 import asyncHandler from '../configs/async-handler.js';
 import userController from '../controllers/user-controller.js';
-// import { createUserSchema, updateUserSchema } from '../dtos/user-dto.js';
+import { createUserSchema, updateUserSchema } from '../dtos/user-dto.js';
 import { validate } from '../middlewares/validate.js';
 
 const router = Router();
 
-// router.post('/', validate(createUserSchema), asyncHandler(userController.createUser));
-router.post('/', asyncHandler(userController.createUser)); // 유효성 검사 임시 비활성화
+router.post('/', validate(createUserSchema), asyncHandler(userController.createUser));
 
+// ------유저(자신) 개인정보 조회, 수정 API ------
 router.get('/me', asyncHandler(userController.getMe)); // /:id 보다 위에 위치해야 함
-router.patch('/me', asyncHandler(userController.updateMe)); // /:id 보다 위에 위치해야 함
+router.patch('/me', validate(updateUserSchema), asyncHandler(userController.updateMe)); // /:id 보다 위에 위치해야 함
 router.delete('/me', asyncHandler(userController.deleteMe)); // /:id 보다 위에 위치해야 함
 
-// admin 계정 관리자 기능을 위해 남겨둠
+// ------ 관리자용 API ------
 router.get('/:id', asyncHandler(userController.getUserById));
-// router.patch('/:id', validate(updateUserSchema), asyncHandler(userController.updateUser));
-router.patch('/:id', asyncHandler(userController.updateUser)); // 유효성 검사 임시 비활성화
+router.patch('/:id', asyncHandler(userController.updateUser));
 router.delete('/:id', asyncHandler(userController.deleteUser));
 
 export default router;

--- a/src/routes/user-route.ts
+++ b/src/routes/user-route.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import asyncHandler from '../configs/async-handler.js';
+import userController from '../controllers/user-controller.js';
+// import { createUserSchema, updateUserSchema } from '../dtos/user-dto.js';
+import { validate } from '../middlewares/validate.js';
+
+const router = Router();
+
+// router.post('/', validate(createUserSchema), asyncHandler(userController.createUser));
+router.post('/', asyncHandler(userController.createUser)); // 유효성 검사 임시 비활성화
+
+router.get('/me', asyncHandler(userController.getMe)); // /:id 보다 위에 위치해야 함
+router.patch('/me', asyncHandler(userController.updateMe)); // /:id 보다 위에 위치해야 함
+router.delete('/me', asyncHandler(userController.deleteMe)); // /:id 보다 위에 위치해야 함
+
+// admin 계정 관리자 기능을 위해 남겨둠
+router.get('/:id', asyncHandler(userController.getUserById));
+// router.patch('/:id', validate(updateUserSchema), asyncHandler(userController.updateUser));
+router.patch('/:id', asyncHandler(userController.updateUser)); // 유효성 검사 임시 비활성화
+router.delete('/:id', asyncHandler(userController.deleteUser));
+
+export default router;

--- a/src/services/company-service.ts
+++ b/src/services/company-service.ts
@@ -1,0 +1,14 @@
+import { CreateCompanyDto } from '../dtos/company-dto.js';
+const companyServie = {
+  async create(companyData: CreateCompanyDto) {
+    const newCompany = await companyRepository.create(companyData);
+    return newCompany;
+  },
+
+  async update() {},
+  async delete() {},
+  async getAll() {},
+  async getById() {},
+};
+
+export default companyServie;

--- a/src/services/company-service.ts
+++ b/src/services/company-service.ts
@@ -1,4 +1,6 @@
 import { CreateCompanyDto } from '../dtos/company-dto.js';
+import companyRepository from '../repositories/company-repository.js';
+
 const companyServie = {
   async create(companyData: CreateCompanyDto) {
     const newCompany = await companyRepository.create(companyData);

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -5,11 +5,6 @@ import bcrypt from 'bcrypt';
 
 const userService = {
   async createUser(userData: CreateUserDto) {
-    // 1. 비밀번호와 비밀번호 확인 일치 여부 확인
-    if (userData.password !== userData.passwordConfirmation) {
-      throw new Error('비밀번호와 비밀번호 확인이 일치하지 않습니다');
-    }
-
     // 2. 이메일 중복 확인
     const existingUser = await userRepository.findByEmail(userData.email);
     if (existingUser) {
@@ -105,11 +100,8 @@ const userService = {
 
     const dataToUpdate: { [key: string]: any } = { ...updateFields };
 
-    // 3. 새로운 비밀번호가 있다면, 검증 후 해싱
+    // 3. 새로운 비밀번호가 있다면 해싱
     if (password) {
-      if (password !== passwordConfirmation) {
-        throw new Error('비밀번호와 비밀번호 확인이 일치하지 않습니다');
-      }
       dataToUpdate.password = await bcrypt.hash(password, 10);
     }
 

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,0 +1,145 @@
+import userRepository from '../repositories/user-repository.js';
+import companyRepository from '../repositories/company-repository.js';
+import { CreateUserDto, UpdateUserDto } from '../dtos/user-dto.js';
+import bcrypt from 'bcrypt';
+
+const userService = {
+  async createUser(userData: CreateUserDto) {
+    // 1. 비밀번호와 비밀번호 확인 일치 여부 확인
+    if (userData.password !== userData.passwordConfirmation) {
+      throw new Error('비밀번호와 비밀번호 확인이 일치하지 않습니다');
+    }
+
+    // 2. 이메일 중복 확인
+    const existingUser = await userRepository.findByEmail(userData.email);
+    if (existingUser) {
+      throw new Error('이미 존재하는 이메일입니다');
+    }
+
+    // 3. 회사 정보 검증
+    const company = await companyRepository.findByNameAndAuthCode(
+      userData.company,
+      userData.companyCode
+    );
+    if (!company) {
+      throw new Error('회사 정보가 올바르지 않습니다.');
+    }
+
+    // 4. 비밀번호 해싱
+    const hashedPassword = await bcrypt.hash(userData.password, 10);
+
+    // 5. 레포지토리에 넘길 데이터 준비
+    const dataToCreate = {
+      name: userData.name,
+      email: userData.email,
+      employeeNumber: userData.employeeNumber,
+      phoneNumber: userData.phoneNumber,
+      password: hashedPassword,
+      companyId: company.id,
+    };
+
+    const newUser = await userRepository.create(dataToCreate);
+
+    // 7. API 명세서에 맞는 응답 형태로 가공
+    const response = {
+      id: newUser.id,
+      name: newUser.name,
+      email: newUser.email,
+      employeeNumber: newUser.employeeNumber,
+      phoneNumber: newUser.phoneNumber,
+      imageUrl: newUser.imageUrl,
+      isAdmin: newUser.isAdmin,
+      company: {
+        companyCode: newUser.company.authCode,
+      },
+    };
+
+    return response;
+  },
+
+  async getUserById(id: number) {
+    const user = await userRepository.findById(id);
+
+    if (!user) {
+      throw new Error('존재하지 않는 유저입니다');
+    }
+
+    // API 명세서에 맞는 응답 형태로 가공
+    const response = {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      employeeNumber: user.employeeNumber,
+      phoneNumber: user.phoneNumber,
+      imageUrl: user.imageUrl,
+      isAdmin: user.isAdmin,
+      company: {
+        companyCode: user.company.authCode,
+      },
+    };
+
+    return response;
+  },
+
+  async updateUser(id: number, userData: UpdateUserDto) {
+    const { currentPassword, password, passwordConfirmation, ...updateFields } =
+      userData;
+
+    // 1. 유저 존재 여부 확인
+    const existingUser = await userRepository.findById(id);
+    if (!existingUser) {
+      throw new Error('존재하지 않는 유저입니다.');
+    }
+
+    // 2. 현재 비밀번호 검증
+    if (!currentPassword) {
+      throw new Error('현재 비밀번호를 입력해주세요.');
+    }
+    const isPasswordValid = await bcrypt.compare(
+      currentPassword,
+      existingUser.password
+    );
+    if (!isPasswordValid) {
+      throw new Error('현재 비밀번호가 일치하지 않습니다.');
+    }
+
+    const dataToUpdate: { [key: string]: any } = { ...updateFields };
+
+    // 3. 새로운 비밀번호가 있다면, 검증 후 해싱
+    if (password) {
+      if (password !== passwordConfirmation) {
+        throw new Error('비밀번호와 비밀번호 확인이 일치하지 않습니다');
+      }
+      dataToUpdate.password = await bcrypt.hash(password, 10);
+    }
+
+    // 4. 정보 업데이트
+    const updatedUser = await userRepository.update(id, dataToUpdate);
+
+    // 5. 응답 데이터 가공
+    const response = {
+      id: updatedUser.id,
+      name: updatedUser.name,
+      email: updatedUser.email,
+      employeeNumber: updatedUser.employeeNumber,
+      phoneNumber: updatedUser.phoneNumber,
+      imageUrl: updatedUser.imageUrl,
+      isAdmin: updatedUser.isAdmin,
+      company: {
+        companyCode: updatedUser.company.authCode,
+      },
+    };
+
+    return response;
+  },
+
+  async deleteUser(id: number) {
+    const existingUser = await userRepository.findById(id);
+    if (!existingUser) {
+      throw new Error('존재하지 않는 유저입니다.');
+    }
+    await userRepository.delete(id);
+  },
+};
+
+export default userService;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,10 @@
+import Express from 'express';
+import User from './user.ts';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user: User;
+    }
+  }
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,6 +1,8 @@
 import Express from 'express';
+import type { Request, Response } from 'express';
 import User from './user.ts';
 
+// 기존 Express 네임스페이스 확장 (Request 인터페이스에 user 속성 추가)
 declare global {
   namespace Express {
     interface Request {
@@ -8,3 +10,6 @@ declare global {
     }
   }
 }
+
+// 비동기 요청 핸들러 타입 정의
+export type AsyncRequestHandler = (req: Request, res: Response) => Promise<void> | void;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,11 +1,5 @@
-interface Us3er {
+interface User {
   id: number;
-  email: string;
-  password: string;
-  nickname: string;
-  image: string | null;
-  createdAt: Date;
-  updatedAt: Date;
 }
 
 export default User;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,11 @@
+interface Us3er {
+  id: number;
+  email: string;
+  password: string;
+  nickname: string;
+  image: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export default User;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,44 +1,47 @@
 {
-  // Visit https://aka.ms/tsconfig to read more about this file
   "compilerOptions": {
-    // File Layout
-    // "rootDir": "./src",
-    // "outDir": "./dist",
-
-    // Environment Settings
-    // See also https://aka.ms/tsconfig/module
+    // Basics
     "module": "nodenext",
-    "target": "esnext",
-    "types": [],
-    // For nodejs:
-    // "lib": ["esnext"],
-    // "types": ["node"],
-    // and npm install -D @types/node
+    "target": "es2024",
+    "lib": ["esnext"],
+    "types": ["node"], // install -D @types/node
+
+    // File Layout
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist",
 
     // Other Outputs
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
+    "removeComments": true,
+
+    // Decorators
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
 
     // Stricter Typechecking Options
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
 
     // Style Options
-    // "noImplicitReturns": true,
-    // "noImplicitOverride": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
-    // "noFallthroughCasesInSwitch": true,
-    // "noPropertyAccessFromIndexSignature": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noUncheckedSideEffectImports": true,
+    "forceConsistentCasingInFileNames": false,
+    "strictNullChecks": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
 
     // Recommended Options
-    "strict": true,
-    "jsx": "react-jsx",
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
+    "incremental": true,
     "skipLibCheck": true,
-  }
+    //"strict": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": false,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*", "test"]
 }


### PR DESCRIPTION
## 📝 배경 (Background)
   - 프로젝트의 핵심 기능인 유저 도메인의 기반을 마련하기 위해, API 명세서에 따른 기본적인 CRUD API를 구현했습니다.
  ---

 ## 🔗 관련 이슈 (Related Issues)
   - Closes # (여기에 관련 이슈 번호를 넣어주세요)

  ---

  ## 💡 구현 사항 (Implementation Details)
initialSetting 브랜치의 마지막 커밋 기준으로 코드 작성했습니다
   - 주요 변경 파일/기능:
       - src/services/user-service.ts: 회원가입, 내 정보 조회/수정/삭제 비즈니스 로직을 구현했습니다.
           - bcrypt를 이용한 비밀번호 해싱 및 검증 로직을 추가했습니다.
       - src/controllers/user-controller.ts: createUser, getMe, updateMe, deleteMe 등 API 요청을 받아 서비스와 연결하는 컨트롤러 
         함수들을 추가했습니다.
       - src/repositories/user-repository.ts: Prisma를 사용하여 User 테이블에 접근하는 CRUD 함수들을 구현했습니다.
       - src/routes/user-route.ts: /users와 /users/me 엔드포인트에 대한 라우팅 규칙을 정의했습니다.
       - src/dtos/user-dto.ts: zod를 사용하여 회원가입 및 정보 수정 시의 데이터 유효성 검사 스키마(createUserSchema, 
         updateUserSchema)를 추가했습니다.
       - src/middlewares/validate.ts: 유효성 검사 미들웨어의 버그를 수정하여 req.body를 올바르게 검증하도록 변경했습니다.
       - app.ts: dotenv 설정을 추가하고, 생성된 userRouter를 미들웨어로 등록했습니다.

   - 핵심 로직 설명:
       - 회원가입: companyCode 검증, 이메일 중복 확인, 비밀번호 해싱 후 DB에 유저를 생성합니다.
       - 내 정보 수정/삭제: 비밀번호 2차 검증을 통과해야만 기능이 동작하도록 구현했습니다.
       - API 라우팅: 인증된 사용자가 본인 정보를 다루는 API는 /me 경로로, 관리자가 특정 유저를 다루는 API는 /:id 경로로 구분하여 
         설계했습니다.

  ---

  ## 🔍 리뷰 요청사항 (Review Request)
   - user-service.ts의 updateUser 함수에서, 현재 비밀번호 검증 및 새로운 비밀번호 업데이트 로직이 안전하게 처리되었는지 확인 
     부탁드립니다.
   - 전체적인 API 흐름이 Layered Architecture 원칙에 맞게 잘 분리되었는지 리뷰 부탁드리겠습니다

  ---

  ## 🛠️ 이후 후속 작업 (Next Steps / Follow-up Tasks)
   - 글로벌 에러 핸들러를 구현하여, 서비스 로직에서 발생하는 에러(예: 이메일 중복)에 대해 명세서에 맞는 HTTP 상태 코드(409, 400 
     등)를 반환하도록 개선할 예정입니다.
   - 로그인 API 및 JWT 인증 미들웨어 구현이 필요합니다.
   => 인증 기능 추가 안해서 아직 api 테스트를 전체적으로 진행 못했습니다

  ---

 ## 📢 알리고 싶은 사항 (Notes / Announcements)
   - dotenv 라이브러리가 프로젝트에 추가되었으므로, 로컬에서 실행 전 npm install 실행이 필요합니다.
   - 로컬 실행을 위해서는 프로젝트 루트에 .env 파일을 생성하고 DATABASE_URL을 설정해야 합니다. (.env.sample 파일 참고)