### PR TITLE
유저/ 인증 피드백 적용

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   isAdmin        Boolean  @default(false) @map("is_admin")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
+  currentHashedRefreshToken String?  @map("current_hashed_refresh_token")
 
   company   Company @relation(fields: [companyId], references: [id])
   companyId Int     @map("company_id")

--- a/src/configs/token.ts
+++ b/src/configs/token.ts
@@ -1,16 +1,18 @@
 import jwt from 'jsonwebtoken';
-import { ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET } from './constants.js';
+import {
+  ACCESS_TOKEN_SECRET,
+  REFRESH_TOKEN_SECRET,
+  ACCESS_TOKEN_EXPIRES_IN,
+  REFRESH_TOKEN_EXPIRES_IN,
+} from './constants.js';
 
 function generateTokens(userId: number) {
-  if (!ACCESS_TOKEN_SECRET || !REFRESH_TOKEN_SECRET) {
-    throw new Error('토큰 시크릿이 설정되지 않았습니다.');
-  }
   const accessToken = jwt.sign({ id: userId }, ACCESS_TOKEN_SECRET, {
-    expiresIn: '1h',
-  });
+    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+  } as jwt.SignOptions);
   const refreshToken = jwt.sign({ id: userId }, REFRESH_TOKEN_SECRET, {
-    expiresIn: '7d',
-  });
+    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+  } as jwt.SignOptions);
 
   return { accessToken, refreshToken };
 }

--- a/src/dtos/user-dto.ts
+++ b/src/dtos/user-dto.ts
@@ -8,8 +8,8 @@ export const createUserSchema = z
     phoneNumber: z.string().min(1, '전화번호는 필수입니다.'),
     password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
     passwordConfirmation: z.string(),
-    company: z.string().min(1, '회사 이름은 필수입니다.'),
-    companyCode: z.string().length(6, '회사 코드는 6자리여야 합니다.'),
+    companyName: z.string().min(1, '회사 이름은 필수입니다.'),
+    companyCode: z.string().min(1, '회사 코드는 필수입니다.'),
   })
   .refine((data) => data.password === data.passwordConfirmation, {
     message: '비밀번호와 비밀번호 확인이 일치하지 않습니다.',

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -36,6 +36,13 @@ const userRepository = {
     });
   },
 
+  async updateRefreshToken(id: number, hashedRefreshToken: string | null) {
+    await prisma.user.update({
+      where: { id },
+      data: { currentHashedRefreshToken: hashedRefreshToken },
+    });
+  },
+
   async delete(id: number) {
     return prisma.user.delete({
       where: { id },

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,15 +1,11 @@
-import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
-import userRepository from '../repositories/user-repository.js';
-import userService from './user-service.js';
+import jwt from 'jsonwebtoken';
+import { REFRESH_TOKEN_SECRET } from '../configs/constants.js';
+import { generateTokens } from '../configs/token.js';
 import { LoginDto, RefreshDto } from '../dtos/auth-dto.js';
 import { NotFoundError, UnauthorizedError } from '../configs/custom-error.js';
-import {
-  ACCESS_TOKEN_SECRET,
-  REFRESH_TOKEN_SECRET,
-  ACCESS_TOKEN_EXPIRES_IN,
-  REFRESH_TOKEN_EXPIRES_IN,
-} from '../configs/constants.js';
+import userRepository from '../repositories/user-repository.js';
+import userService from './user-service.js';
 
 const authService = {
   async login(loginDto: LoginDto) {
@@ -28,14 +24,13 @@ const authService = {
     }
 
     // 3. 토큰 생성
-    const accessToken = jwt.sign({ id: user.id }, ACCESS_TOKEN_SECRET, {
-      expiresIn: ACCESS_TOKEN_EXPIRES_IN,
-    } as jwt.SignOptions);
-    const refreshToken = jwt.sign({ id: user.id }, REFRESH_TOKEN_SECRET, {
-      expiresIn: REFRESH_TOKEN_EXPIRES_IN,
-    } as jwt.SignOptions);
+    const { accessToken, refreshToken } = generateTokens(user.id);
 
-    // 4. 응답 데이터 가공 (userService 재사용)
+    // 4. Refresh Token 해싱 및 DB 저장
+    const hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
+    await userRepository.updateRefreshToken(user.id, hashedRefreshToken);
+
+    // 5. 응답 데이터 가공
     const userProfile = await userService.getUserById(user.id);
 
     return {
@@ -49,32 +44,36 @@ const authService = {
     const { refreshToken } = refreshDto;
 
     try {
-      // 1. Refresh Token 검증
-      const decoded = jwt.verify(refreshToken, REFRESH_TOKEN_SECRET) as {
-        id: number;
-      };
+      // 1. Refresh Token 자체의 유효성 검증 (만료 등)
+      const decoded = jwt.verify(refreshToken, REFRESH_TOKEN_SECRET) as { id: number };
 
-      // 2. 유저 존재 여부 확인
+      // 2. DB에서 유저 정보 및 저장된 토큰 조회
       const user = await userRepository.findById(decoded.id);
-      if (!user) {
-        throw new UnauthorizedError('유효하지 않은 토큰입니다.');
+      if (!user || !user.currentHashedRefreshToken) {
+        throw new UnauthorizedError('유효하지 않은 토큰입니다. (사용자 또는 토큰 없음)');
       }
 
-      // 3. 새로운 토큰 생성
-      const newAccessToken = jwt.sign({ id: user.id }, ACCESS_TOKEN_SECRET, {
-        expiresIn: ACCESS_TOKEN_EXPIRES_IN,
-      } as jwt.SignOptions);
-      const newRefreshToken = jwt.sign({ id: user.id }, REFRESH_TOKEN_SECRET, {
-        expiresIn: REFRESH_TOKEN_EXPIRES_IN,
-      } as jwt.SignOptions);
+      // 3. 전달된 토큰과 DB의 토큰이 일치하는지 확인
+      const isTokenValid = await bcrypt.compare(refreshToken, user.currentHashedRefreshToken);
+      if (!isTokenValid) {
+        throw new UnauthorizedError('유효하지 않은 토큰입니다. (토큰 불일치)');
+      }
+
+      // 4. 새로운 토큰 생성
+      const { accessToken: newAccessToken, refreshToken: newRefreshToken } = generateTokens(user.id);
+
+      // 5. 새로 발급한 Refresh Token을 다시 해싱하여 DB에 저장 (교체)
+      const hashedNewRefreshToken = await bcrypt.hash(newRefreshToken, 10);
+      await userRepository.updateRefreshToken(user.id, hashedNewRefreshToken);
 
       return {
         accessToken: newAccessToken,
         refreshToken: newRefreshToken,
       };
     } catch (error) {
-      // 토큰이 만료되었거나, 형식이 잘못된 경우
-      throw new UnauthorizedError('유효하지 않은 토큰입니다.');
+      // UnauthorizedError가 아닌 다른 에러(jwt.verify 에러 등) 처리
+      if (error instanceof UnauthorizedError) throw error;
+      throw new UnauthorizedError('유효하지 않은 토큰입니다. (검증 실패)');
     }
   },
 };

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -18,7 +18,7 @@ const userService = {
 
     // 3. 회사 정보 검증
     const company = await companyRepository.findByNameAndAuthCode(
-      userData.company,
+      userData.companyName,
       userData.companyCode
     );
     if (!company) {


### PR DESCRIPTION
 ## 배경 (Background)
   - 이전 User 및 Auth 기능 PR에 대한 코드 리뷰 피드백을 반영 했습니다

  ---

  ## 🔗 관련 이슈 (Related Issues)
   - Resolves #16
   - Related #34 

  ---

  ## 💡 구현 사항 (Implementation Details)
   - 주요 변경 파일/기능:
       - dtos/user-dto.ts: 회원가입 DTO의 company 필드를 companyName으로 변경하고, companyCode의 유효성 검사 규칙을 완화(length(6) → min(1))했습니다.
       - configs/token.ts: 하드코딩되어 있던 토큰 만료 시간을 환경 변수(constants.ts)에서 가져오도록 수정했습니다.
       - services/auth-service.ts: token.ts의 generateTokens 함수를 사용하도록 리팩토링하여 중복 
         코드를 제거하고, Refresh Token Rotation 로직을 구현했습니다.
       - prisma/schema.prisma: User 모델에 해싱된 Refresh Token을 저장하기 위한 
         currentHashedRefreshToken 필드를 추가했습니다.
       - repositories/user-repository.ts: 유저의 Refresh Token을 DB에 업데이트하기 위한 
         updateRefreshToken 함수를 추가했습니다.

   - 핵심 로직 설명:
       - 피드백 반영: 프론트엔드와의 데이터 형식 일치를 위해 DTO 필드명을 수정하고, 불필하게 엄격했던  유효성 검사 규칙을 완화했습니다.
       - Refresh Token Rotation:
           1. 로그인 시: 발급된 Refresh Token을 해싱하여 DB에 저장합니다.
           2. 토큰 갱신 시: 전달된 토큰과 DB에 저장된 토큰 해시를 비교하여, 한번 사용된 토큰은 
              재사용될 수 없도록 검증합니다.
           3. 토큰 교체: 검증 성공 시, 새로운 Refresh Token을 발급하고 해시값을 다시 DB에 
              저장(교체)하여 기존 토큰을 무효화합니다.

  ---

  ## 🔍 리뷰 요청사항 (Review Request)
   - auth-service.ts의 login과 refresh 메서드에 Refresh Token Rotation 로직이 보안상 문제없이 
     올바르게 구현되었는지 확인 부탁드립니다.
   - DB 스키마 변경(User 모델에 필드 추가) 및 관련 리포지토리 함수(updateRefreshToken)가 적절하게  추가되었는지 검토 바랍니다.
   - 기존 user/auth 기능이 이번 리팩토링으로 인해 의도치 않은 동작(오류) 가 나오는지 확인이 필요할 것 같습니다

  ---

  🛠️ 이후 후속 작업 (Next Steps / Follow-up Tasks)
   - 

  ---

  ## 📢 알리고 싶은 사항 (Notes / Announcements)
   - 이 PR은 데이터베이스 스키마 변경을 포함합니다. 머지(Merge) 후, 로컬에서 npx prisma db push 명령어를 실행해야 합니다.