### PR TITLE
🚀 feat: 대시보드 API 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -881,6 +881,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1827,6 +1828,7 @@
       "version": "9.36.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4011,8 +4013,11 @@
     },
     "node_modules/prisma": {
       "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.17.1.tgz",
+      "integrity": "sha512-ac6h0sM1Tg3zu8NInY+qhP/S9KhENVaw9n1BrGKQVFu05JT5yT5Qqqmb8tMRIE3ZXvVj4xcRA5yfrsy4X7Yy5g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.17.1",
         "@prisma/engines": "6.17.1"
@@ -4931,6 +4936,7 @@
       "version": "5.9.2",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/prisma/seeds/06-contract.seed.ts
+++ b/prisma/seeds/06-contract.seed.ts
@@ -1,0 +1,73 @@
+import { PrismaClient, ContractStatus, CarType } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function seed() {
+  console.log('Seeding contracts...');
+
+  // 1. 기존 데이터 가져오기 (이전 시드 파일에서 생성됨)
+  const company = await prisma.company.findFirst();
+  const user = await prisma.user.findFirst();
+  const customers = await prisma.customer.findMany({ take: 5 });
+  const cars = await prisma.car.findMany({ take: 5 });
+
+  if (!company || !user || customers.length < 5 || cars.length < 5) {
+    console.error('⚠️ 필수 데이터(회사, 유저, 고객, 차량)가 부족하여 계약 시드를 생성할 수 없습니다.');
+    return;
+  }
+
+  // 2. 샘플 계약 데이터 생성
+  const contracts = [
+    // --- 이번 달 완료된 계약 ---
+    {
+      status: ContractStatus.contractSuccessful,
+      contractPrice: 35000000,
+      resolutionDate: new Date(), // 오늘
+      carId: cars[0].id,
+      customerId: customers[0].id,
+    },
+    {
+      status: ContractStatus.contractSuccessful,
+      contractPrice: 22000000,
+      resolutionDate: new Date(new Date().setDate(new Date().getDate() - 3)), // 3일 전
+      carId: cars[1].id,
+      customerId: customers[1].id,
+    },
+    // --- 지난 달 완료된 계약 ---
+    {
+      status: ContractStatus.contractSuccessful,
+      contractPrice: 18000000,
+      resolutionDate: new Date(new Date().setMonth(new Date().getMonth() - 1)), // 1달 전
+      carId: cars[2].id,
+      customerId: customers[2].id,
+    },
+    // --- 진행중인 계약 ---
+    {
+      status: ContractStatus.carInspection,
+      contractPrice: 41000000,
+      resolutionDate: null,
+      carId: cars[3].id,
+      customerId: customers[3].id,
+    },
+    {
+      status: ContractStatus.priceNegotiation,
+      contractPrice: 28000000,
+      resolutionDate: null,
+      carId: cars[4].id,
+      customerId: customers[4].id,
+    },
+  ];
+
+  // 3. 데이터베이스에 생성
+  for (const contract of contracts) {
+    await prisma.contract.create({
+      data: {
+        ...contract,
+        companyId: company.id,
+        userId: user.id,
+      },
+    });
+  }
+
+  console.log(`${contracts.length}개의 계약 데이터가 생성되었습니다.`);
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,10 +13,11 @@ import authRoute from './routes/auth-route.js';
 import imageRoute from './routes/image-route.js';
 import customerRoutes from './routes/customer-routes.js';
 import carRoute from './routes/car-route.js';
-
 import { PORT, CORS_ORIGINS, NODE_ENV, BASE_URL } from './configs/constants.js';
 import { notFoundHandler } from './middlewares/not-found-handler.js';
 import { errorHandler } from './middlewares/error-handler.js';
+// import contractRouter from './routes/contract-route.js';
+import dashboardRoute from './routes/dashboard-route.js';
 
 const app = express();
 const port = Number(PORT) || 3001;
@@ -82,9 +83,7 @@ app.use('/auth', authRoute);
 app.use('/images', imageRoute);
 app.use('/customers', customerRoutes);
 app.use('/cars', carRoute);
-// app.use('/contracts', contractRoute);
-// app.use('/contracts', contractRoute);
-// app.use('/contracts', contractRoute);
+app.use('/dashboard', dashboardRoute);
 
 // ==========================
 // ❌ 404 핸들러

--- a/src/controllers/dashboard-controller.ts
+++ b/src/controllers/dashboard-controller.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express';
+import asyncHandler from '../configs/async-handler.js';
+import dashboardService from '../services/dashboard-service.js';
+
+const dashboardController = {
+  getDashboardData: asyncHandler(async (req: Request, res: Response) => {
+    // 'authenticate' 미들웨어가 req.user 객체를 보장합니다.
+    const user = req.user;
+    const companyId = user.companyId;
+
+    const dashboardData = await dashboardService.getDashboardData(companyId);
+
+    res.status(200).json(dashboardData);
+  }),
+};
+
+export default dashboardController;

--- a/src/dtos/dashboard-dto.ts
+++ b/src/dtos/dashboard-dto.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+// contractsByCarType, salesByCarType 배열의 각 요소에 대한 스키마
+const carTypeStatSchema = z.object({
+  carType: z.string(),
+  count: z.number(),
+});
+
+// 전체 대시보드 응답에 대한 스키마
+export const DashboardResponseSchema = z.object({
+  monthlySales: z.number(),
+  lastMonthSales: z.number(),
+  growthRate: z.number(),
+  proceedingContractsCount: z.number(),
+  completedContractsCount: z.number(),
+  contractsByCarType: z.array(carTypeStatSchema),
+  salesByCarType: z.array(carTypeStatSchema),
+});
+
+// 스키마로부터 TypeScript 타입 추론
+export type DashboardResponseDto = z.infer<typeof DashboardResponseSchema>;

--- a/src/dtos/dashboard-dto.ts
+++ b/src/dtos/dashboard-dto.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
+import { CarType } from '@prisma/client';
 
 // contractsByCarType, salesByCarType 배열의 각 요소에 대한 스키마
 const carTypeStatSchema = z.object({
-  carType: z.string(),
+  carType: z.nativeEnum(CarType),
   count: z.number(),
 });
 

--- a/src/repositories/dashboard-repository.ts
+++ b/src/repositories/dashboard-repository.ts
@@ -1,0 +1,116 @@
+import prisma from '../configs/prisma-client.js';
+import { ContractStatus } from '@prisma/client';
+
+const dashboardRepository = {
+  /**
+   * 특정 기간 동안의 총 매출액(성사된 계약)을 조회합니다.
+   */
+  async getSalesByDateRange(companyId: number, startDate: Date, endDate: Date) {
+    const result = await prisma.contract.aggregate({
+      _sum: {
+        contractPrice: true,
+      },
+      where: {
+        companyId,
+        status: ContractStatus.contractSuccessful,
+        resolutionDate: {
+          gte: startDate,
+          lt: endDate,
+        },
+      },
+    });
+    return result._sum.contractPrice ?? 0;
+  },
+
+  /**
+   * 현재 진행 중인 계약의 총 개수를 조회합니다.
+   */
+  async getProceedingContractsCount(companyId: number) {
+    return prisma.contract.count({
+      where: {
+        companyId,
+        status: {
+          in: [
+            ContractStatus.carInspection,
+            ContractStatus.priceNegotiation,
+            ContractStatus.contractDraft,
+          ],
+        },
+      },
+    });
+  },
+
+  /**
+   * 특정 기간 동안 완료된 계약의 총 개수를 조회합니다.
+   */
+  async getCompletedContractsCountByDateRange(
+    companyId: number,
+    startDate: Date,
+    endDate: Date,
+  ) {
+    return prisma.contract.count({
+      where: {
+        companyId,
+        status: ContractStatus.contractSuccessful,
+        resolutionDate: {
+          gte: startDate,
+          lt: endDate,
+        },
+      },
+    });
+  },
+
+  /**
+   * 차종별 계약 수를 집계합니다.
+   */
+  async getContractsCountByCarType(companyId: number) {
+    return prisma.contract.groupBy({
+      by: ['carId'],
+      _count: {
+        id: true,
+      },
+      where: {
+        companyId,
+      },
+    });
+  },
+
+  /**
+   * 차종별 매출액을 집계합니다.
+   */
+  async getSalesByCarType(companyId: number) {
+    return prisma.contract.groupBy({
+      by: ['carId'],
+      _sum: {
+        contractPrice: true,
+      },
+      where: {
+        companyId,
+        status: ContractStatus.contractSuccessful,
+      },
+    });
+  },
+
+  /**
+   * 주어진 ID 목록에 해당하는 차량들의 차종을 조회합니다.
+   */
+  async getCarTypesByIds(carIds: number[]) {
+    return prisma.car.findMany({
+      where: {
+        id: {
+          in: carIds,
+        },
+      },
+      select: {
+        id: true,
+        model: {
+          select: {
+            type: true,
+          },
+        },
+      },
+    });
+  },
+};
+
+export default dashboardRepository;

--- a/src/routes/dashboard-route.ts
+++ b/src/routes/dashboard-route.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import dashboardController from '../controllers/dashboard-controller.js';
+import { authenticate } from '../middlewares/authenticate.js';
+
+const router = Router();
+
+// GET /dashboard - 대시보드 통계 조회
+router.get(
+  '/',
+  authenticate, // 인증 미들웨어 적용
+  dashboardController.getDashboardData
+);
+
+export default router;

--- a/src/services/dashboard-service.ts
+++ b/src/services/dashboard-service.ts
@@ -1,0 +1,68 @@
+import dashboardRepository from '../repositories/dashboard-repository.js';
+import { DashboardResponseDto } from '../dtos/dashboard-dto.js';
+import { CarType } from '@prisma/client';
+
+const dashboardService = {
+  async getDashboardData(companyId: number): Promise<DashboardResponseDto> {
+    // 1. 날짜 범위 계산
+    const now = new Date();
+    const firstDayCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    const firstDayNextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    const firstDayLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+
+    // 2. 레포지토리로부터 데이터 병렬 조회
+    const [ 
+      monthlySales, 
+      lastMonthSales, 
+      proceedingContractsCount, 
+      completedContractsCount, 
+      contractsByCar, 
+      salesByCar
+    ] = await Promise.all([
+      dashboardRepository.getSalesByDateRange(companyId, firstDayCurrentMonth, firstDayNextMonth),
+      dashboardRepository.getSalesByDateRange(companyId, firstDayLastMonth, firstDayCurrentMonth),
+      dashboardRepository.getProceedingContractsCount(companyId),
+      dashboardRepository.getCompletedContractsCountByDateRange(companyId, firstDayCurrentMonth, firstDayNextMonth),
+      dashboardRepository.getContractsCountByCarType(companyId),
+      dashboardRepository.getSalesByCarType(companyId),
+    ]);
+
+    // 3. 차종별 집계를 위한 추가 데이터 조회 및 가공
+    const allCarIds = [...new Set([...contractsByCar.map(c => c.carId), ...salesByCar.map(s => s.carId)])];
+    const carIdToTypeMap = new Map<number, CarType>();
+    if (allCarIds.length > 0) {
+      const carTypes = await dashboardRepository.getCarTypesByIds(allCarIds);
+      carTypes.forEach(car => carIdToTypeMap.set(car.id, car.model.type));
+    }
+
+    const aggregateByCarType = <T extends { carId: number; }>(groups: T[], getValue: (item: T) => number) => {
+      const result = new Map<CarType, number>();
+      groups.forEach(group => {
+        const carType = carIdToTypeMap.get(group.carId);
+        if (carType) {
+          result.set(carType, (result.get(carType) ?? 0) + getValue(group));
+        }
+      });
+      return Array.from(result, ([carType, count]) => ({ carType, count }));
+    };
+
+    const contractsByCarType = aggregateByCarType(contractsByCar, (item) => item._count.id);
+    const salesByCarType = aggregateByCarType(salesByCar, (item) => item._sum.contractPrice ?? 0);
+
+    // 4. 성장률 계산
+    const growthRate = lastMonthSales === 0 ? 0 : ((monthlySales - lastMonthSales) / lastMonthSales) * 100;
+
+    // 5. 최종 DTO 조립
+    return {
+      monthlySales,
+      lastMonthSales,
+      growthRate,
+      proceedingContractsCount,
+      completedContractsCount,
+      contractsByCarType,
+      salesByCarType,
+    };
+  },
+};
+
+export default dashboardService;


### PR DESCRIPTION
# 🚀 feat: 대시보드 API 기능 구현

  ## 📝 배경 (Background)
  서비스의 핵심 지표(이 달의 매출, 계약 현황 등)를 한눈에 파악할 수 있는 대시보드 통계 API (GET /dashboard)를 구현했습니다.

  ---

  ## 🔗 관련 이슈 (Related Issues)
   * Resolves #38 

  ---

  ## 💡 구현 사항 (Implementation Details)
  대시보드 통계 API를 구성하는 전체 계층(Route, Controller, Service, Repository, DTO)을 구현했습니다.

   * 주요 변경 파일/기능:
       * src/routes/dashboard-route.ts: GET /dashboard 엔드포인트 정의 및 인증 미들웨어 적용
       * src/controllers/dashboard-controller.ts: 요청을 받아 서비스에 작업을 위임하고 응답을 반환
       * src/services/dashboard-service.ts: 통계 계산을 위한 핵심 비즈니스 로직 구현
       * src/repositories/dashboard-repository.ts: Prisma의 aggregate와 groupBy를 사용하여 효율적인 데이터 집계 쿼리를 작성했습니다.
       * src/dtos/dashboard-dto.ts: API 응답 형식을 위한 DTO를 정의했습니다.
       * prisma/seeds/06-contract.seed.ts: 대시보드 기능 테스트를 위한 샘플 계약 데이터를 생성하는 시드 스크립트를 추가했습니다.
       * src/app.ts: 생성된 대시보드 라우터를 애플리케이션에 등록했습니다.

  ---

  ## 🔍 리뷰 요청사항 (Review Request)
   * dashboard-repository.ts에 작성된 Prisma 집계 쿼리들이 비즈니스 요구사항에 맞게 효율적으로 작성되었는지 확인 부탁드립니다.
   * dashboard-service.ts에서 여러 비동기 데이터를 조합하고 성장률 등을 계산하는 로직에 더 좋은 방법이 있을지 의견을 구합니다.

  ---

  ## 📢 알리고 싶은 사항 (Notes / Announcements)
   * 이 PR에는 새로운 시드(seed) 스크립트가 포함되어 있습니다.
   * 로컬에서 테스트하시려면, 브랜치를 받으신 후 반드시 아래 명령어를 실행하여 데이터베이스를 초기화하고 샘플 데이터를 생성해 주세요.     
   * npm run db:refresh
