### PR TITLE
feature: 권한 미들웨어 추가

### DIFF
--- a/src/middlewares/authorize.ts
+++ b/src/middlewares/authorize.ts
@@ -1,0 +1,10 @@
+import type { Request, Response, NextFunction } from 'express';
+import { ForbiddenError } from '../configs/custom-error.js';
+
+export function isAdmin(req: Request, _res: Response, next: NextFunction) {
+  // authenticate 미들웨어에서 req.user를 보장해 주지만, 안전을 위해 추가 확인
+  if (!req.user || !req.user.isAdmin) {
+    return next(new ForbiddenError('관리자 권한이 필요합니다.'));
+  }
+  next();
+}

--- a/src/routes/company-route.ts
+++ b/src/routes/company-route.ts
@@ -9,6 +9,7 @@ import {
   getUsersByCompanySchema,
 } from '../dtos/company-dto.js';
 import { authenticate } from '../middlewares/authenticate.js';
+import { isAdmin } from '../middlewares/authorize.js';
 import { validate } from '../middlewares/validate.js';
 
 const router = Router();
@@ -82,6 +83,7 @@ const router = Router();
 router.post(
   '/',
   authenticate,
+  isAdmin,
   validate(createCompanySchema, 'body'),
   asyncHandler(companyController.create),
 );
@@ -238,6 +240,7 @@ router.get(
 router.patch(
   '/:companyId',
   authenticate,
+  isAdmin,
   validate(companyIdParamsSchema, 'params'),
   validate(updateCompanySchema, 'body'),
   asyncHandler(companyController.update),
@@ -269,6 +272,7 @@ router.patch(
 router.delete(
   '/:companyId',
   authenticate,
+  isAdmin,
   validate(companyIdParamsSchema, 'params'),
   asyncHandler(companyController.delete),
 );

--- a/src/routes/user-route.ts
+++ b/src/routes/user-route.ts
@@ -4,6 +4,7 @@ import userController from '../controllers/user-controller.js';
 import { createUserSchema, updateUserSchema } from '../dtos/user-dto.js';
 import { validate } from '../middlewares/validate.js';
 import { authenticate } from '../middlewares/authenticate.js';
+import { isAdmin } from '../middlewares/authorize.js';
 
 const router = Router();
 
@@ -194,7 +195,7 @@ router.delete('/me', authenticate, asyncHandler(userController.deleteMe));
  *       404:
  *         description: 사용자를 찾을 수 없음
  */
-router.get('/:id', asyncHandler(userController.getUserById));
+router.get('/:id', authenticate, isAdmin, asyncHandler(userController.getUserById));
 
 /**
  * @swagger
@@ -235,7 +236,7 @@ router.get('/:id', asyncHandler(userController.getUserById));
  *       404:
  *         description: 사용자를 찾을 수 없음
  */
-router.patch('/:id', asyncHandler(userController.updateUser));
+router.patch('/:id', authenticate, isAdmin, asyncHandler(userController.updateUser));
 
 /**
  * @swagger
@@ -260,6 +261,6 @@ router.patch('/:id', asyncHandler(userController.updateUser));
  *       404:
  *         description: 사용자를 찾을 수 없음
  */
-router.delete('/:id', asyncHandler(userController.deleteUser));
+router.delete('/:id', authenticate, isAdmin, asyncHandler(userController.deleteUser));
 
 export default router;


### PR DESCRIPTION
# feature: 관리자 API에 대한 권한 검사 로직 추가

  ## 📝 배경 (Background)
  기존에는 일반 사용자도 토큰 인증만 통과하면 회사 생성/삭제, 다른 사용자 정보 수정/삭제 등 관리자 전용 API를 호출할 수 있는 보안
  문제가 있었습니다. 이 PR은 이를 해결하여 오직 관리자만 해당 API를 사용할 수 있도록 접근을 제어합니다.

  ---

 ## 🔗 관련 이슈 (Related Issues)
   * #67

  ---

 ## 💡 구현 사항 (Implementation Details)
 

   * 주요 변경 파일/기능:
       * src/middlewares/authorize.ts: isAdmin 권한 검사 미들웨어를 신규 생성했습니다.
       * src/routes/company-route.ts: 회사 생성, 수정, 삭제 API에 isAdmin 미들웨어를 적용했습니다.
       * src/routes/user-route.ts: 특정 사용자 조회, 수정, 삭제 API에 authenticate 및 isAdmin 미들웨어를 적용했습니다.
   * 핵심 로직 설명:
       * authenticate 미들웨어 실행 후, req.user.isAdmin 값을 확인하는 isAdmin 미들웨어를 추가했습니다.
       * isAdmin이 false일 경우, 403 Forbidden 에러를 반환하여 이후 로직 실행을 차단합니다.
       * 이 미들웨어를 관리자 전용 라우트에 선언적으로 적용하여, 서비스나 컨트롤러 코드 수정 없이 보안을 강화했습니다.

  스크린샷 또는 GIF (Optional)
   * 해당 없음 (백엔드 로직 변경)

  ---

  ## 🔍 리뷰 요청사항 (Review Request)
   * 새로 추가된 isAdmin 미들웨어 로직이 명확하고 안전하게 구현되었는지 확인 부탁드립니다.
   * company-route.ts와 user-route.ts 외에 추가로 보호해야 할 관리자 API가 있는지 함께 검토해주시면 감사하겠습니다.

  ---

  ## 🛠️ 이후 후속 작업 (Next Steps / Follow-up Tasks)
   * 해당 없음

  ---

  ## 📢 알리고 싶은 사항 (Notes / Announcements)
   따로 npm install은 진행 안해도 될거같습니다.
   local POSTMAN에서 api 테스트 전부 완료했습니다.